### PR TITLE
Update for 0.10.2

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -18,10 +18,10 @@
     "output"
   ],
   "dependencies": {
-    "purescript-generics": "^1.0.0",
-    "purescript-strongcheck": "^1.0.0"
+    "purescript-generics": "^3.1.0",
+    "purescript-strongcheck": "^2.0.1"
   },
   "devDependencies": {
-    "purescript-console": "^1.0.0"
+    "purescript-console": "^2.0.0"
   }
 }

--- a/src/Test/StrongCheck/Generic.purs
+++ b/src/Test/StrongCheck/Generic.purs
@@ -20,7 +20,7 @@ import Data.Generic (class Generic, GenericSignature(..), GenericSpine(..), isVa
 import Data.Int (toNumber)
 import Data.List (fromFoldable)
 import Data.Maybe (Maybe(..), maybe, fromJust)
-import Data.Monoid.Endo (Endo(..), runEndo)
+import Data.Monoid.Endo (Endo(..))
 import Data.Traversable (for, traverse)
 import Data.Tuple (Tuple(..))
 
@@ -51,7 +51,7 @@ gCoarbitrary = go <<< toSpine
     go SUnit = coarbitrary unit
 
 applyAll :: forall f a. Foldable f => f (a -> a) -> a -> a
-applyAll = runEndo <<< foldMap Endo
+applyAll = (case _ of Endo a -> a) <<< foldMap Endo
 
 -- | Contains representation of an arbitrary value.
 -- | Consists of `GenericSpine` and corresponding `GenericSignature`.

--- a/test/Main.purs
+++ b/test/Main.purs
@@ -3,6 +3,7 @@ module Test.Main where
 import Prelude
 
 import Control.Monad.Trampoline (runTrampoline)
+import Control.Monad.Eff.Console as Console
 
 import Data.Array (null)
 import Data.Foldable (any)
@@ -13,6 +14,7 @@ import Partial.Unsafe (unsafePartial)
 import Test.StrongCheck (SC, quickCheck, assert)
 import Test.StrongCheck.Arbitrary (class Coarbitrary, class Arbitrary)
 import Test.StrongCheck.Gen (Gen, GenState(..), showSample, collectAll)
+import Test.StrongCheck.LCG (mkSeed)
 import Test.StrongCheck.Generic (gArbitrary, gCoarbitrary)
 
 import StrongCheckExample (exampleMain)
@@ -33,7 +35,7 @@ derive instance genericUninhabited :: Partial => Generic Uninhabited
 -- | Check that `gArbitrary :: Gen Uninhabited` results into an empty generator
 assert_uninhabited :: Boolean
 assert_uninhabited = unsafePartial $ null $ runTrampoline $ collectAll state (gArbitrary :: Gen Uninhabited)
-  where state = GenState { seed: 42.0, size: 42 }
+  where state = GenState { seed: mkSeed 42, size: 42 }
 
 data MyList a = Nil | Cons (MyList a)
 derive instance genericMyList :: Generic a => Generic (MyList a)
@@ -67,5 +69,6 @@ props_gArbitrary = do
 
 main :: SC () Unit
 main = do
-  props_gArbitrary
-  exampleMain
+  Console.log "hello world"
+  -- props_gArbitrary
+  -- exampleMain

--- a/test/Main.purs
+++ b/test/Main.purs
@@ -3,7 +3,6 @@ module Test.Main where
 import Prelude
 
 import Control.Monad.Trampoline (runTrampoline)
-import Control.Monad.Eff.Console as Console
 
 import Data.Array (null)
 import Data.Foldable (any)
@@ -69,6 +68,5 @@ props_gArbitrary = do
 
 main :: SC () Unit
 main = do
-  Console.log "hello world"
-  -- props_gArbitrary
-  -- exampleMain
+  props_gArbitrary
+  exampleMain


### PR DESCRIPTION
This PR updates the library for the 0.10.2 release of the compiler.

Running `pulp test` hangs forever. Removing both of the function calls in `main` didn't change that behavior. I've updated another dependency to point to this branch, and the tests in that case work fine.