### PR TITLE
Deprecate package on Pursuit

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -4,6 +4,7 @@
   "authors": [
     "Konstantin Zudov <co@zudov.me"
   ],
+  "keywords": ["pursuit-deprecated"],
   "repository": {
     "type": "git",
     "url": "git://github.com/zudov/purescript-strongcheck-generics.git"

--- a/bower.json
+++ b/bower.json
@@ -7,7 +7,7 @@
   "keywords": ["pursuit-deprecated"],
   "repository": {
     "type": "git",
-    "url": "git://github.com/zudov/purescript-strongcheck-generics.git"
+    "url": "https://github.com/zudov/purescript-strongcheck-generics.git"
   },
   "moduleType": [
     "node"


### PR DESCRIPTION
This PR makes the changes required to [deprecate this package on Pursuit](https://pursuit.purescript.org/help/authors#package-deprecation), since it depends on [purescript-strongcheck](https://github.com/purescript-deprecated/purescript-strongcheck), which is also deprecated.

A new package version would need to be published after this PR is merged.